### PR TITLE
feat(service): create PokemonService with basic CRUD operations

### DIFF
--- a/src/main/java/com/myprojects/mypokeapi/service/PokemonService.java
+++ b/src/main/java/com/myprojects/mypokeapi/service/PokemonService.java
@@ -1,4 +1,58 @@
 package com.myprojects.mypokeapi.service;
 
+import com.myprojects.mypokeapi.dto.PokemonDTO;
+import com.myprojects.mypokeapi.entity.Pokemon;
+import com.myprojects.mypokeapi.repository.PokemonRepository;
+import com.myprojects.mypokeapi.util.AppConstants;
+//import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
 public class PokemonService {
+    
+    private final PokemonRepository pokemonRepository;
+
+    public PokemonService(PokemonRepository pokemonRepository) {
+        this.pokemonRepository = pokemonRepository;
+    }
+
+    public Page<Pokemon> getAllPokemons(Pageable pageable) {
+        return pokemonRepository.findAll(pageable);
+    }
+
+    public Optional<Pokemon> getPokemonById(Long id) {
+        return pokemonRepository.findById(id);
+    }
+
+    public Pokemon createPokemon(PokemonDTO pokemonDTO) {
+        Pokemon pokemon = new Pokemon();
+        pokemon.setName(pokemonDTO.getName());
+        pokemon.setType(Pokemon.Type.valueOf(pokemonDTO.getType().toUpperCase()));
+        return pokemonRepository.save(pokemon);
+    }
+
+    public Pokemon updatePokemon(Long id, PokemonDTO pokemonDTO) {
+        Optional<Pokemon> optionalPokemon = pokemonRepository.findById(id);
+        if (optionalPokemon.isPresent()) {
+            Pokemon pokemon = optionalPokemon.get();
+            if (pokemonDTO.getName() != null) {
+                pokemon.setName(pokemonDTO.getName());
+            }
+            if (pokemonDTO.getType() != null) {
+                pokemon.setType(Pokemon.Type.valueOf(pokemonDTO.getType().toUpperCase()));
+            }
+            return pokemonRepository.save(pokemon);
+        }
+        throw new RuntimeException("Pokemon not found with id " + id);
+    }
+
+    public void deletePokemon(Long id) {
+        pokemonRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/myprojects/mypokeapi/util/AppConstants.java
+++ b/src/main/java/com/myprojects/mypokeapi/util/AppConstants.java
@@ -1,0 +1,6 @@
+package com.myprojects.mypokeapi.util;
+
+public class AppConstants {
+    public static final String DEFAULT_PAGE_NUMBER = "0";
+    public static final String DEFAULT_PAGE_SIZE = "10";
+}


### PR DESCRIPTION
# Descripción del Pull Request para la rama `feature/Service-implementation`

## Resumen
Este Pull Request introduce la implementación de servicios para la gestión de Pokémon en nuestra aplicación MyPokeAPI. Se ha desarrollado una capa de servicio que encapsula la lógica de negocio relacionada con las operaciones CRUD (Crear, Leer, Actualizar, Eliminar) de Pokémon, mejorando así la separación de responsabilidades y la mantenibilidad del código.

## Cambios Principales
- Se ha añadido la clase `PokemonService` que ofrece métodos para realizar operaciones CRUD sobre Pokémon.
- Implementación de métodos en `PokemonService` para interactuar con la base de datos a través de `PokemonRepository`, incluyendo la creación, actualización, obtención y eliminación de Pokémon.
- Se ha utilizado el patrón DTO (Data Transfer Object) para la transferencia de datos entre la capa de servicio y los controladores, asegurando que solo se expongan los datos necesarios.

## Cómo Probar
1. Realizar solicitudes a los endpoints que utilizan los servicios implementados y verificar que las operaciones CRUD sobre Pokémon funcionen correctamente.
2. Utilizar DTOs para crear o actualizar Pokémon y comprobar que solo los datos permitidos son procesados.
3. Ejecutar las pruebas unitarias y de integración para asegurar que la lógica de negocio funciona como se espera.