### PR TITLE
feat(controller): implement PokemonController with CRUD endpoints, pa…

### DIFF
--- a/src/main/java/com/myprojects/mypokeapi/controller/PokemonController.java
+++ b/src/main/java/com/myprojects/mypokeapi/controller/PokemonController.java
@@ -1,0 +1,61 @@
+package com.myprojects.mypokeapi.controller;
+
+import com.myprojects.mypokeapi.dto.PokemonDTO;
+import com.myprojects.mypokeapi.entity.Pokemon;
+import com.myprojects.mypokeapi.service.PokemonService;
+import com.myprojects.mypokeapi.util.AppConstants;
+//import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/pokemons")
+public class PokemonController {
+
+    private final PokemonService pokemonService;
+
+    public PokemonController(PokemonService pokemonService) {
+        this.pokemonService = pokemonService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<Pokemon>> getAllPokemons(
+            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_NUMBER) int page,
+            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_SIZE) int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Pokemon> resultPage = pokemonService.getAllPokemons(pageable);
+        return new ResponseEntity<>(resultPage, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Pokemon> getPokemonById(@PathVariable Long id) {
+        Optional<Pokemon> pokemon = pokemonService.getPokemonById(id);
+        return pokemon.map(value -> new ResponseEntity<>(value, HttpStatus.OK))
+                .orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    @PostMapping
+    public ResponseEntity<Pokemon> createPokemon(@Valid @RequestBody PokemonDTO pokemonDTO) {
+        Pokemon createdPokemon = pokemonService.createPokemon(pokemonDTO);
+        return new ResponseEntity<>(createdPokemon, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Pokemon> updatePokemon(@PathVariable Long id, @Valid @RequestBody PokemonDTO pokemonDTO) {
+        Pokemon updatedPokemon = pokemonService.updatePokemon(id, pokemonDTO);
+        return new ResponseEntity<>(updatedPokemon, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePokemon(@PathVariable Long id) {
+        pokemonService.deletePokemon(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/myprojects/mypokeapi/service/PokemonService.java
+++ b/src/main/java/com/myprojects/mypokeapi/service/PokemonService.java
@@ -3,7 +3,7 @@ package com.myprojects.mypokeapi.service;
 import com.myprojects.mypokeapi.dto.PokemonDTO;
 import com.myprojects.mypokeapi.entity.Pokemon;
 import com.myprojects.mypokeapi.repository.PokemonRepository;
-import com.myprojects.mypokeapi.util.AppConstants;
+//import com.myprojects.mypokeapi.util.AppConstants;
 //import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +15,7 @@ import java.util.Optional;
 @Service
 @Transactional
 public class PokemonService {
-    
+
     private final PokemonRepository pokemonRepository;
 
     public PokemonService(PokemonRepository pokemonRepository) {


### PR DESCRIPTION
# Descripción del Pull Request para la rama `feature/Controller-implementation`

## Resumen
Este Pull Request introduce la implementación completa del controlador para la gestión de Pokémon en nuestra aplicación MyPokeAPI. Se han desarrollado endpoints CRUD (Crear, Leer, Actualizar, Eliminar) para los Pokémon, permitiendo una interacción eficiente y segura con la base de datos a través de la API.

## Cambios Principales
- Implementación de endpoints en `PokemonController` para realizar operaciones CRUD sobre Pokémon.
- Uso de `PokemonDTO` para la transferencia de datos en las solicitudes de creación y actualización, asegurando que solo se manejen los datos necesarios y validados.
- Implementación de validaciones en los DTOs para garantizar la integridad de los datos recibidos en las solicitudes.
- Configuración de respuestas HTTP adecuadas para cada operación, mejorando la claridad de la comunicación con los clientes de la API.

## Cómo Probar
1. Realizar solicitudes HTTP a los endpoints definidos para verificar la correcta ejecución de las operaciones CRUD.
2. Enviar datos no válidos en las solicitudes de creación y actualización para probar las validaciones implementadas.
3. Comprobar las respuestas HTTP en diferentes escenarios (creación exitosa, error en la solicitud, etc.) para asegurar que son adecuadas y descriptivas.