### PR TITLE
feat(general): fixing DB and pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/myprojects/mypokeapi/controller/PokemonController.java
+++ b/src/main/java/com/myprojects/mypokeapi/controller/PokemonController.java
@@ -4,7 +4,6 @@ import com.myprojects.mypokeapi.dto.PokemonDTO;
 import com.myprojects.mypokeapi.entity.Pokemon;
 import com.myprojects.mypokeapi.service.PokemonService;
 import com.myprojects.mypokeapi.util.AppConstants;
-//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +17,6 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/api/pokemons")
 public class PokemonController {
-
     private final PokemonService pokemonService;
 
     public PokemonController(PokemonService pokemonService) {
@@ -28,9 +26,11 @@ public class PokemonController {
     @GetMapping
     public ResponseEntity<Page<Pokemon>> getAllPokemons(
             @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_NUMBER) int page,
-            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_SIZE) int size) {
+            @RequestParam(defaultValue = AppConstants.DEFAULT_PAGE_SIZE) int size,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) Pokemon.Type type) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Pokemon> resultPage = pokemonService.getAllPokemons(pageable);
+        Page<Pokemon> resultPage = pokemonService.getAllPokemons(pageable, name, type);
         return new ResponseEntity<>(resultPage, HttpStatus.OK);
     }
 

--- a/src/main/java/com/myprojects/mypokeapi/repository/PokemonRepository.java
+++ b/src/main/java/com/myprojects/mypokeapi/repository/PokemonRepository.java
@@ -1,9 +1,16 @@
 package com.myprojects.mypokeapi.repository;
 
 import com.myprojects.mypokeapi.entity.Pokemon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PokemonRepository extends JpaRepository<Pokemon, Long> {
+    Page<Pokemon> findByType(Pokemon.Type typeFilter, Pageable pageable);
+
+    Page<Pokemon> findByNameContainingIgnoreCase(String nameFilter, Pageable pageable);
+
+    Page<Pokemon> findByNameContainingIgnoreCaseAndType(String nameFilter, Pokemon.Type typeFilter, Pageable pageable);
 }

--- a/src/main/java/com/myprojects/mypokeapi/service/PokemonService.java
+++ b/src/main/java/com/myprojects/mypokeapi/service/PokemonService.java
@@ -4,8 +4,8 @@ import com.myprojects.mypokeapi.dto.PokemonDTO;
 import com.myprojects.mypokeapi.entity.Pokemon;
 import com.myprojects.mypokeapi.repository.PokemonRepository;
 //import com.myprojects.mypokeapi.util.AppConstants;
-//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,15 +15,22 @@ import java.util.Optional;
 @Service
 @Transactional
 public class PokemonService {
-
     private final PokemonRepository pokemonRepository;
 
     public PokemonService(PokemonRepository pokemonRepository) {
         this.pokemonRepository = pokemonRepository;
     }
 
-    public Page<Pokemon> getAllPokemons(Pageable pageable) {
-        return pokemonRepository.findAll(pageable);
+    public Page<Pokemon> getAllPokemons(Pageable pageable, String nameFilter, Pokemon.Type typeFilter) {
+        if (nameFilter != null && typeFilter != null) {
+            return pokemonRepository.findByNameContainingIgnoreCaseAndType(nameFilter, typeFilter, pageable);
+        } else if (nameFilter != null) {
+            return pokemonRepository.findByNameContainingIgnoreCase(nameFilter, pageable);
+        } else if (typeFilter != null) {
+            return pokemonRepository.findByType(typeFilter, pageable);
+        } else {
+            return pokemonRepository.findAll(pageable);
+        }
     }
 
     public Optional<Pokemon> getPokemonById(Long id) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,7 @@ spring.flyway.locations=classpath:db/migration
 
 # Port configuration
 server.port=8080
+
+# Security configuration
+spring.security.user.name=user
+spring.security.user.password=password

--- a/src/main/resources/db/migration/V1__Create_initial_schema.sql
+++ b/src/main/resources/db/migration/V1__Create_initial_schema.sql
@@ -1,9 +1,0 @@
-CREATE TABLE pokemon (
-                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                         name VARCHAR(255) NOT NULL,
-                         type VARCHAR(255) NOT NULL,
-                         level INT NOT NULL,
-                         hp INT NOT NULL,
-                         attack INT NOT NULL,
-                         defense INT NOT NULL
-);

--- a/src/main/resources/db/migration/V2__Create_initial_schema.sql
+++ b/src/main/resources/db/migration/V2__Create_initial_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE pokemon (
+                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                         name VARCHAR(255) NOT NULL,
+                         type VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
# Implement database fixes and enhance pagination with filtering options

## Changes

### 1. Database schema refactoring
- Updated migration scripts (V1 and V2) to modify the Pokemon table structure
- Removed some fields from the original schema (level, hp, attack, defense)

### 2. Enhanced pagination and filtering
- Added support for filtering by name and type in `PokemonRepository`
- Updated `PokemonService` to handle new filtering options
- Modified `PokemonController` to accept name and type parameters

### 3. Security configuration
- Added basic security settings in `application.properties`

### 4. Code improvements
- Removed unused imports and commented-out code
- Updated method signatures in service and controller layers

### 5. Dependency updates
- Minor changes to `pom.xml`

## Summary
These changes aim to improve the database structure, add more flexible querying options, and implement basic security measures. Testing and documentation updates may be required.
